### PR TITLE
fix: add nghttp2 dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL version="0.0.1"
 LABEL repository="https://github.com/minddocdev/ci-actions/deploy"
 LABEL maintainer="MindDoc Health GmbH"
 
-RUN apk add --no-cache nodejs npm
+RUN apk add --no-cache nghttp2-dev nodejs npm
 
 COPY lib/ /usr/src/
 COPY package.json /usr/src


### PR DESCRIPTION
Fixes the following error in the pipelines:
```
  Error relocating /usr/bin/node: nghttp2_option_set_max_settings: symbol not found
  The command '/bin/sh -c npm install --only=prod' returned a non-zero code: 127
  Warning: Docker build failed with exit code 127, back off 4.225 seconds before retry.
  /usr/bin/docker build -t cc4956:67da7736ce3642cf8d2e26ed628d7e34 -f "/home/runner/work/_actions/minddocdev/helm-action/master/Dockerfile" "/home/runner/work/_actions/minddocdev/helm-action/master"
  Sending build context to Docker daemon  225.8kB
```