### PR TITLE
chore: update base image version to 3.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@
 # image:    deploy
 # name:     minddocdev/ci-actions/deploy
 # repo:     https://github.com/minddocdev/ci-actions/deploy
-# Requires: minddocdev/kubernetes-deploy:3.0.0
+# Requires: minddocdev/kubernetes-deploy:3.5.3
 # authors:  development@minddoc.com
 # ------------------------------------------------------
 
-FROM minddocdev/kubernetes-deploy:3.0.0
+FROM minddocdev/kubernetes-deploy:3.5.3
 
 LABEL version="0.0.1"
 LABEL repository="https://github.com/minddocdev/ci-actions/deploy"


### PR DESCRIPTION
The new base image ships with helm version 3.5.3